### PR TITLE
main: Change digit/anal method prefix to digital/analog

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -327,12 +327,12 @@ static LSMethod serviceMethods[] = {
    {"setWiringPiPhys", setWiringPiPhys},
    {"setWiringPiSys", setWiringPiSys},
    {"setPinMode", setPinMode},
-   {"digitWrite", digitWrite},
+   {"digitalWrite", digitWrite},
    {"setPullUpDnControl", setPullUpDnControl},
    {"writePwm", writePwm},
-   {"digitRead", digitRead},
-   {"analRead", analRead},
-   {"analWrite", analWrite},
+   {"digitalRead", digitRead},
+   {"analogRead", analRead},
+   {"analogWrite", analWrite},
    {"setWiringPiSPI",setWiringPiSPI},
    {"wiringPiSPIRWData", wiringPiSPIRWData}
 };


### PR DESCRIPTION
digital/analog are well-known prefix by embedded developers.
Although the prefix are used in wiringPI for its services,
They can be used for the prefix in string constants.