### PR TITLE
Modified API group name for ACG and Service Type

### DIFF
--- a/files/sysbus/com.webos.service.rpi.gpio.api.json
+++ b/files/sysbus/com.webos.service.rpi.gpio.api.json
@@ -1,5 +1,5 @@
 {
-    "public": [
+    "rpi.gpio": [
         "com.webos.service.rpi.gpio/gpio", 
 	"com.webos.service.rpi.gpio/wiringPiSetup",
 	"com.webos.service.rpi.gpio/wiringPiSetupPhys",

--- a/files/sysbus/com.webos.service.rpi.gpio.perm.json
+++ b/files/sysbus/com.webos.service.rpi.gpio.perm.json
@@ -1,5 +1,5 @@
 {
     "com.webos.service.rpi.gpio": [
-        "public"
+        "rpi.gpio"
     ]
 }

--- a/files/sysbus/com.webos.service.rpi.gpio.service.in
+++ b/files/sysbus/com.webos.service.rpi.gpio.service.in
@@ -3,4 +3,4 @@ Name=com.webos.service.rpi.gpio
 Exec=/usr/bin/gpio load i2c
 Exec=/usr/bin/gpio load spi
 Exec=/usr/sbin/com.webos.service.rpi.gpio
-Type=static
+Type=dynamic


### PR DESCRIPTION
Modified API Group for ACG
From "public" To "rpi.gpio"

Modified Service Type
From "static" To "dynamic"